### PR TITLE
types: allow string[] input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 export default function dedent(input: string): string;
 export default function dedent(
-  input: TemplateStringsArray,
+  input: TemplateStringsArray | string[],
   ...values: any[]
 ): string;
 export default function dedent(
-  input: string | TemplateStringsArray,
+  input: string | string[] | TemplateStringsArray,
   ...values: any[]
-) {
+): string {
   const strings = typeof input === "string" ? [input] : input;
   const m = /^\r?\n?([\t ]+)/.exec(strings[0]);
   let indent = m ? m[1] : "";


### PR DESCRIPTION
This function works outside of a tagged template, however the types did not allow it.